### PR TITLE
Fix event for custom element

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -169,9 +169,20 @@ export function createShikiTextarea(styles: Record<string, string>) {
               spellcheck={false}
               class={styles.textarea}
               disabled={!config.editable}
-              onInput={e => {
-                const value = e.currentTarget.value
+              on:input={e => {
+                const target = e.currentTarget
+                const value = target.value
+
+                // local
                 setSource(value)
+
+                // copy to custom element document fragment
+                const rootNode = target.getRootNode()
+                if (rootNode && rootNode instanceof ShadowRoot) {
+                  rootNode.value = value
+                }
+
+                // user provided callback
                 config.onInput?.(e)
               }}
               value={config.value}

--- a/src/custom-element.tsx
+++ b/src/custom-element.tsx
@@ -97,6 +97,7 @@ class ShikiTextareaElement extends Element {
   @booleanAttribute editable = true
 
   template = () => {
+    // styles
     const adoptedStyleSheets = this.shadowRoot!.adoptedStyleSheets
 
     adoptedStyleSheets.push(ShikiTextareaStyleSheet)
@@ -105,6 +106,12 @@ class ShikiTextareaElement extends Element {
       adoptedStyleSheets.push(sheet(this.stylesheet))
     }
 
+    // copy event from shadowRoot to local instance
+    this.shadowRoot.addEventListener('input', e => {
+      this.value = this.shadowRoot.value
+    })
+
+    // theme
     const [theme] = createResource(
       () => this.theme,
       async theme => {
@@ -118,6 +125,8 @@ class ShikiTextareaElement extends Element {
         )
       },
     )
+
+    // lang
     const [lang] = createResource(
       () => this.lang,
       async lang => {


### PR DESCRIPTION
 
1. catches the `oninput` event from the `textarea` and copies it to `shadowRoot.value`
2. the `oninput` listener from the `shadowRoot` copies  `shadowRoot.value` to `this.value`  (the custom element instance `<shiki-textarea/>` so it can be accessed by `event.target.value` and also nice to have `querySelector('shiki-textarea').value`

Kind of a juggling, I will ask Joe if there's a better way to do this