### PR TITLE
round

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,20 +32,14 @@ The main export of `solid-shiki-textarea` is a solid component.
 import type { LanguageRegistration, ThemeRegistration } from 'shiki'
 import type { Language, Theme } from 'shiki-textarea/tm'
 
-type LanguageProps = 
-  | Language 
-  | LanguageRegistration[] 
-  | Promise<LanguageRegistration[]>
+type LanguageProps = Language | LanguageRegistration[] | Promise<LanguageRegistration[]>
 
-type ThemeProps = 
-  | Theme 
-  | ThemeRegistration 
-  | Promise<ThemeRegistration>
+type ThemeProps = Theme | ThemeRegistration | Promise<ThemeRegistration>
 
 interface ShikiTextareaProps extends Omit<ComponentProps<'div'>, 'style'> {
   language: LanguageProps
   theme: ThemeProps
-  value: string
+  code: string
   editable?: boolean
   style?: JSX.CSSProperties
   onInput?: (event: InputEvent & { currentTarget: HTMLTextAreaElement }) => void
@@ -67,7 +61,7 @@ export default () => (
   <ShikiTextarea
     language={tsx}
     theme={minLight}
-    value="const sum = (a: string, b: string) => a + b"
+    code="const sum = (a: string, b: string) => a + b"
     editable={true}
     style={{
       padding: '10px',
@@ -87,7 +81,7 @@ export default () => (
   <ShikiTextarea
     language={import('https://esm.sh/shiki/langs/tsx.mjs')}
     theme={import('https://esm.sh/shiki/themes/min-light.mjs')}
-    value="const sum = (a: string, b: string) => a + b"
+    code="const sum = (a: string, b: string) => a + b"
     editable={true}
     style={{
       padding: '10px',
@@ -107,12 +101,12 @@ We also export a custom-element wrapper `<shiki-textarea/>` powered by
 <summary>Attribute Types</summary>
 
 ```ts
-import { LanguageProps, ThemeProps } from "shiki-textarea"
+import { LanguageProps, ThemeProps } from 'shiki-textarea'
 
 interface ShikiTextareaAttributes extends ComponentProps<'div'> {
   language?: LanguageProps
   theme?: ThemeProps
-  value?: string
+  code?: string
   editable?: boolean
   stylesheet?: string | CSSStyleSheet
   onInput?: (event: InputEvent & { currentTarget: ShikiTextareaElement }) => void
@@ -133,7 +127,7 @@ export default () => (
   <shiki-textarea
     language="tsx"
     theme="andromeeda"
-    value="const sum = (a: string, b: string) => a + b"
+    code="const sum = (a: string, b: string) => a + b"
     editable={true}
     style={{
       padding: '10px',
@@ -181,7 +175,7 @@ different `shiki-textarea` instances.
 <shiki-textarea
   language="tsx"
   theme="andromeeda"
-  value="const sum = (a: string, b: string) => a + b"
+  code="const sum = (a: string, b: string) => a + b"
   editable={true}
   style={{
     '--padding': '10px',

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -230,6 +230,7 @@ export function createShikiTextarea(styles: Record<string, string>) {
           ...config.style,
         }}
         {...rest}
+        data-editable={config.editable}
       >
         <div class={styles.container}>
           <code part="code" class={styles.code} innerHTML={html() || previous} />

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -127,7 +127,7 @@ export interface ShikiTextareaProps extends Omit<ComponentProps<'div'>, 'style' 
    */
   theme: ThemeProp
   /** The source code to be displayed and edited. */
-  value: string
+  code: string
   /** Callback function to handle updates to the source code. */
   onInput?: (event: InputEvent & { currentTarget: HTMLTextAreaElement }) => void
 }
@@ -138,12 +138,12 @@ export function createShikiTextarea(styles: Record<string, string>) {
       'class',
       'language',
       'onInput',
-      'value',
+      'code',
       'style',
       'theme',
       'editable',
     ])
-    const [source, setSource] = createSignal(config.value)
+    const [source, setSource] = createSignal(config.code)
 
     // lang
     const [language] = createResource(
@@ -219,7 +219,7 @@ export function createShikiTextarea(styles: Record<string, string>) {
 
     // NOTE:  Update to projection once this lands in solid 2.0
     //        Sync local source signal with config.source
-    createRenderEffect(() => setSource(config.value))
+    createRenderEffect(() => setSource(config.code))
 
     return (
       <div
@@ -247,16 +247,10 @@ export function createShikiTextarea(styles: Record<string, string>) {
               // local
               setSource(value)
 
-              // copy to custom element document fragment
-              const rootNode = target.getRootNode()
-              if (rootNode && rootNode instanceof ShadowRoot) {
-                rootNode.value = value
-              }
-
               // user provided callback
               config.onInput?.(e)
             }}
-            value={config.value}
+            value={config.code}
           />
         </div>
       </div>

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -77,6 +77,14 @@ export function urlFromCdn(type: 'theme' | 'language', key: string) {
 /*                                                                                */
 /**********************************************************************************/
 
+declare module 'solid-js/jsx-runtime' {
+  namespace JSX {
+    interface CustomEvents {
+      input: InputEvent
+    }
+  }
+}
+
 export type LanguageProp = Language | Promise<LanguageRegistration[]> | LanguageRegistration[]
 
 export type ThemeProp =

--- a/src/custom-element.tsx
+++ b/src/custom-element.tsx
@@ -6,6 +6,8 @@ import {
   ElementAttributes,
   stringAttribute,
 } from '@lume/element'
+import type { LumeElement } from '@lume'
+
 import { createShikiTextarea, LanguageProp, ThemeProp } from './core'
 import classnames from './index.module.css?classnames'
 import css from './index.module.css?raw'
@@ -19,7 +21,7 @@ import { sheet } from './utils/sheet.js'
 
 interface ShikiTextareaAttributes
   extends Omit<
-    ElementAttributes<ShikiTextareaElement, 'language' | 'theme' | 'value' | 'editable'>,
+    ElementAttributes<ShikiTextareaElement, 'language' | 'theme' | 'code' | 'editable'>,
     'onInput' | 'oninput'
   > {
   oninput?: (event: InputEvent & { currentTarget: ShikiTextareaElement }) => any
@@ -55,33 +57,36 @@ const ShikiTextareaStyleSheet = sheet(css)
 class ShikiTextareaElement extends Element {
   @attribute() language: LanguageProp = 'tsx'
   @attribute() theme: ThemeProp = 'andromeeda'
-  @stringAttribute value = ''
+  @stringAttribute code = ''
   @stringAttribute stylesheet = ''
   @booleanAttribute editable = true
+  input: LumeElement = null
 
   template = () => {
-    // styles
     const adoptedStyleSheets = this.shadowRoot!.adoptedStyleSheets
 
+    // local component stylesheet
     adoptedStyleSheets.push(ShikiTextareaStyleSheet)
 
+    // user provided stylesheet
     if (this.stylesheet) {
       adoptedStyleSheets.push(sheet(this.stylesheet))
     }
 
-    // copy event from shadowRoot to local instance
-    this.shadowRoot.addEventListener('input', e => {
-      this.value = this.shadowRoot.value
-    })
-
-    return (
+    const node: LumeElement = (
       <ShikiTextarea
         language={this.language}
         theme={this.theme}
-        value={this.value}
+        code={this.code}
         editable={this.editable}
       />
     )
+    this.input = node.querySelector('textarea')
+
+    return node
+  }
+  get value() {
+    return this.input.value
   }
 }
 


### PR DESCRIPTION
Hey!  
So this changes the prop name from value to code, so it stops clashing with the `event.target.value`.  Also, we were able to get rid of the event juggling using a getter.  Added a typing, and down to only 1 typescript error xD

In a related note there's a new attribute `data-editable` to ease styling when its editable